### PR TITLE
fixing python syntax error with random 'ls'

### DIFF
--- a/c3python/c3python.py
+++ b/c3python/c3python.py
@@ -141,7 +141,7 @@ class C3Python(object):
             while True:
                 try:
                     log.info(f"Getting C3 client for {self.url}...")
-                    c3 = self.c3iot.C3RemoteLoader.typeSys(ls 
+                    c3 = self.c3iot.C3RemoteLoader.typeSys( 
                         url=self.url,
                         tenant=self.tenant,
                         tag=self.tag,


### PR DESCRIPTION
@dadamsncsa I think there's a random 'ls' that got into the code somehow.
It gives me a syntax error when running it. Removing it fixed it, so I'm proposing this PR.